### PR TITLE
Add the initial action

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,3 +3,4 @@ repository:
   name: terraform-github-check-action
   description: Creates a GitHub check displaying a Terraform plan
   topics: terraform, github, github-action
+  private: false

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,5 @@
+_extends: .github
+repository:
+  name: terraform-github-check-action
+  description: Creates a GitHub check displaying a Terraform plan
+  topics: terraform, github, github-action

--- a/.github/workflows/action-lint.yml
+++ b/.github/workflows/action-lint.yml
@@ -1,0 +1,23 @@
+name: Actionlint
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download actionlint
+        env:
+          ACTIONLINT_VERSION: 1.5.3
+        run: |
+          curl -fsSL  -o actionlint.tgz "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          sudo tar xfz actionlint.tgz -C /usr/local/bin
+      - name: Check workflow files
+        run:  actionlint

--- a/.github/workflows/action-lint.yml
+++ b/.github/workflows/action-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Download actionlint
         env:
-          ACTIONLINT_VERSION: 1.5.3
+          ACTIONLINT_VERSION: 1.6.2
         run: |
           curl -fsSL  -o actionlint.tgz "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           sudo tar xfz actionlint.tgz -C /usr/local/bin

--- a/.github/workflows/update-semver.yml
+++ b/.github/workflows/update-semver.yml
@@ -1,0 +1,13 @@
+name: Update Semver
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+jobs:
+  update-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haya14busa/action-update-semver@v1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # terraform-github-check-action
+
+Creates a GitHub check displaying a Terraform plan.
+
+## Usage
+
+```
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TakeScoop/terraform-cloud-workspace-action
+        name: Manage Terraform Workspaces
+        id: terraform
+        with:
+          terraform_token: "${{ secrets.TF_TOKEN }}"
+          terraform_organization: org 
+          apply: "${{ github.event.inputs.apply == 'true' || github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}"
+      - uses: TakeScoop/terraform-github-check-action
+        name: Create GitHub Check
+        with:
+          github_token: "${{ secrets.GH_TOKEN }}"
+          name: Terraform Cloud Workspace
+          plan: "${{ steps.terraform.outputs.plan }}"
+```
+
+## Inputs
+
+| Name | Description | Default |
+| --- | --- | --- |
+| `github_token` | GitHub token with permission to post GitHub checks. | |
+| `name` | GitHub check name. | |
+| `plan` | Human readable Terraform plan. | |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Creates a GitHub check displaying a Terraform plan.
 
 ## Usage
 
-```
+```yaml
 jobs:
   terraform:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
       - uses: TakeScoop/terraform-github-check-action
         name: Create GitHub Check
         with:
-          github_token: "${{ secrets.GH_TOKEN }}"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
           name: Terraform Cloud Workspace
           plan: "${{ steps.terraform.outputs.plan }}"
 ```

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Add GitHub Check
       uses: LouisBrunner/checks-action@v1.1.1
       with:
-        token: ${{ inputs.github_token }}
-        name: ${{ inputs.name }}
-        conclusion: ${{ job.status }}
+        token: "${{ inputs.github_token }}"
+        name: "${{ inputs.name }} Plan"
+        conclusion: "${{ job.status }}"
         output: "${{ steps.github-check-body.outputs.result }}"

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,35 @@
+name: Create GitHub Terraform Check
+description: Creates a GitHub check displaying a Terraform plan
+inputs:
+  plan:
+    description: Human readable Terraform plan
+    required: true
+  name:
+    description: GitHub check name
+    required: true
+  github_token:
+    description: GitHub token
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Prepare GitHub Check Request
+      id: github-check-body
+      run: |
+        result=$(jq --null-input '{
+          "title": "${{ inputs.name }}",
+          "summary": "Changes planned for ${{ inputs.name }}"
+        }' | jq \
+          --compact-output \
+          --monochrome-output \
+          --arg plan "${{ inputs.plan }}" \
+          '. + { text_description: ("```\n" + $plan + "\n```") }')
+        echo "::set-output name=result::$result"
+      shell: bash
+    - name: Add GitHub Check
+      uses: LouisBrunner/checks-action@v1.1.1
+      with:
+        token: ${{ inputs.github_token }}
+        name: ${{ inputs.name }}
+        conclusion: ${{ job.status }}
+        output: "${{ steps.github-check-body.outputs.result }}"

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
       id: github-check-body
       run: |
         result=$(jq --null-input '{
-          "title": "${{ inputs.name }}",
+          "title": "${{ inputs.name }} Plan",
           "summary": "Changes planned for ${{ inputs.name }}"
         }' | jq \
           --compact-output \


### PR DESCRIPTION
Adds the initial composite action to format and publish a Github check from a passed Terraform plan. It might seem like there's not going on here, and that's correct, but a specific action here gives us the freedom in the future to easily add things like a summary field or other useful information to the check that we might not see as useful now