### PR TITLE
Pass plan via `env`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,11 +22,13 @@ runs:
         }' | jq \
           --compact-output \
           --monochrome-output \
-          --arg plan '${{ inputs.plan }}' \
+          --arg plan "$TERRAFORM_PLAN" \
           '. + { text_description: ("```terraform\n" + $plan + "\n```") }')
 
         echo "::set-output name=result::$result"
       shell: bash
+      env:
+        TERRAFORM_PLAN: ${{ inputs.plan }}
     - name: Add GitHub Check
       uses: LouisBrunner/checks-action@v1.1.1
       with:


### PR DESCRIPTION
Actions inputs are not generally safe for substitution directly into shell scripts. You can do it if you expect the content to be simple, but it opens up the action to syntax errors at best and exploitation at worst:

```yaml
uses: ./my-action
with:
  input: "'; env | copy-to-remote; '"
```

Not sure that exact input results in arbitrary command execution but you get the idea.

Untrusted strings must be passed via declared environment variables to be used safely in shell scripting.

Fixes #6