### PR TITLE
Allow name to be fully customizable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   name:
     description: GitHub check name
-    required: true
+    required: false
     default: Terraform Plan
   github_token:
     description: GitHub token

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,7 @@ inputs:
   name:
     description: GitHub check name
     required: true
+    default: Terraform Plan
   github_token:
     description: GitHub token
     required: true
@@ -33,6 +34,6 @@ runs:
       uses: LouisBrunner/checks-action@v1.1.1
       with:
         token: "${{ inputs.github_token }}"
-        name: "${{ inputs.name }} Plan"
+        name: "${{ inputs.name }}"
         conclusion: "${{ job.status }}"
         output: "${{ steps.github-check-body.outputs.result }}"


### PR DESCRIPTION
We are trying to standardize our GitHub checks of the format:
```
Terraform / check / lint
Terraform / workspace / plan
```

This action takes a stance on the name of the step: `"${{ inputs.name}} Plan"`. 

<img width="485" alt="image" src="https://user-images.githubusercontent.com/8100360/163509022-19facb07-9172-4013-83f1-e98b4b9e4819.png">

It would be nice for us to be able to format the name ourselves so we can set the check name to something like `workspace / changes` or something similar