### PR TITLE
Deprecate in favor of job summaries

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -4,3 +4,4 @@ repository:
   description: Creates a GitHub check displaying a Terraform plan
   topics: terraform, github, github-action
   private: false
+  archived: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # terraform-github-check-action
 
+**Deprecated:** Terraform plans can be included in [GitHub Actions job summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/).
+
 Creates a GitHub check displaying a Terraform plan.
 
 ## Usage


### PR DESCRIPTION
Recommends the use of job summaries instead of using this action to create check runs.